### PR TITLE
Interpret message as UTF-8

### DIFF
--- a/weemoji.py
+++ b/weemoji.py
@@ -39,7 +39,7 @@ except ImportError:
 MATCHER = re.compile(":([+\-]?\w+):")
 
 def interpolate_emoji_cb(data, modifier, modifier_data, message):
-    return MATCHER.sub(replace_emoji, message)
+    return MATCHER.sub(replace_emoji, message.decode('utf-8'))
 
 def emoji_completion_cb(data, completion_item, buffer, completion):
     for key in EMOJI:


### PR DESCRIPTION
Otherwise it is interpreted as ASCII it seems and certain messages produce the following error:

``` text
python: stdout/stderr (weemoji):     return MATCHER.sub(replace_emoji, message)
python: stdout/stderr (weemoji): UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 28: ordinal not in range(128)
python: error in function "interpolate_emoji_cb"
```